### PR TITLE
fix: マイコンがLFの場合に出力が改行されない問題の修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "eslint src --fix && prettier --write \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "prettier": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,md}\""
   },
-  "packageManager": "pnpm@9.3.0",
+  "packageManager": "pnpm@9.4.0",
   "dependencies": {
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",

--- a/src/libs/mrubyWriterConnector.ts
+++ b/src/libs/mrubyWriterConnector.ts
@@ -361,7 +361,7 @@ export class MrubyWriterConnector {
 
   private handleText(text: string): Success<{ event: Event | null }> {
     const last_text = this.buffer.pop() ?? "";
-    const texts = (last_text + text).replace("\r\n", "\n").split("\n");
+    const texts = (last_text + text).replaceAll("\r\n", "\n").split("\n");
     const event = this.detectEvent(texts.join()).value.event;
     this.buffer.push(...texts);
     this.onListen?.(this.buffer);

--- a/src/libs/mrubyWriterConnector.ts
+++ b/src/libs/mrubyWriterConnector.ts
@@ -361,7 +361,7 @@ export class MrubyWriterConnector {
 
   private handleText(text: string): Success<{ event: Event | null }> {
     const last_text = this.buffer.pop() ?? "";
-    const texts = (last_text + text).split("\r\n");
+    const texts = (last_text + text).replace("\r\n", "\n").split("\n");
     const event = this.detectEvent(texts.join()).value.event;
     this.buffer.push(...texts);
     this.onListen?.(this.buffer);


### PR DESCRIPTION
close #103 

- ログ出力部分で受信したCRLFをLFに置換し、すべてLFとして扱うことにより解決