### PR TITLE
fix: フォントのpreload linkタグのパスの誤りを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/images/logo.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="preload" as="font" href="/fonts/MPLUSRounded1c/MPLUSRounded1c-Medium.woff2" crossorigin />
-  <link rel="preload" as="font" href="/fonts/NotoSansMono/NotoSansMono-Regular.woff2" crossorigin />
+  <link rel="preload" as="font" type="font/woff2" href="/fonts/MPLUSRounded1c/MPLUSRounded1c-Medium.woff2" crossorigin />
+  <link rel="preload" as="font" type="font/woff2" href="/fonts/NotoSansMono/NotoSansMono-Regular.woff2" crossorigin />
   <title>Matz葉がにロボコン 書き込みツール</title>
   <style>
     @font-face {

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/images/logo.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="preload" as="font" href="/fonts/MPLUSRounded1c-Medium.woff2" crossorigin />
-  <link rel="preload" as="font" href="/fonts/NotoSansMono-Regular.woff2" crossorigin />
+  <link rel="preload" as="font" href="/fonts/MPLUSRounded1c/MPLUSRounded1c-Medium.woff2" crossorigin />
+  <link rel="preload" as="font" href="/fonts/NotoSansMono/NotoSansMono-Regular.woff2" crossorigin />
   <title>Matz葉がにロボコン 書き込みツール</title>
   <style>
     @font-face {


### PR DESCRIPTION
cf. #186

ライセンスファイルを置くためにディレクトリ構造を変更した後、preload linkタグのhrefを直し忘れていた