### PR TITLE
fix: 無駄なスタイルを整理し画面幅からはみ出ないように修正

### DIFF
--- a/src/components/SourceCodeTab.tsx
+++ b/src/components/SourceCodeTab.tsx
@@ -27,16 +27,15 @@ export const SourceCodeTab = ({ sourceCode }: CodeProps) => {
   return (
     <Box
       sx={{
-        minWidth: "45rem",
+        minWidth: "41rem",
         maxWidth: "65rem",
-        width: "max(100vw, 100dvw, 45rem)",
+        width: "100%",
         mb: isOpen ? "2rem" : "0",
       }}
     >
       <Card
         sx={{
           borderRadius: isOpen ? "1rem" : "1rem 1rem 0 0",
-          margin: "0 2rem",
         }}
       >
         <Button

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -249,19 +249,17 @@ export const Home = () => {
       <UnsupportedBrowserModal defaultOpen={!isSupported} />
       <Box
         sx={{
-          mb: "0.5rem",
           display: "flex",
           width: "100%",
           minWidth: "30rem",
           maxWidth: "65rem",
-          flexDirection: "row",
           flexGrow: "1",
           gap: "1rem",
+          alignSelf: "center",
         }}
       >
         <Box
           sx={{
-            marginLeft: "2rem",
             width: "15rem",
             minWidth: "15rem",
             display: "flex",

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -5,12 +5,10 @@ import { Outlet } from "react-router";
 export const Layout = () => (
   <Box
     sx={{
-      width: "fit-content",
-      height: "fit-content",
-      minWidth: "100vw",
+      width: "100%",
       minHeight: "100vh",
+      minWidth: "44rem",
       "&": {
-        minWidth: "100dvw",
         minHeight: "100dvh",
       },
       background: "white",
@@ -18,10 +16,21 @@ export const Layout = () => (
       flexDirection: "column",
       gap: "2rem",
       alignItems: "center",
-      justifyContent: "center",
     }}
   >
     <Header />
-    <Outlet />
+    <Box
+      sx={{
+        width: "100%",
+        pl: "2rem",
+        pr: "1rem",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "2.5rem",
+      }}
+    >
+      <Outlet />
+    </Box>
   </Box>
 );


### PR DESCRIPTION
close #505

### 背景

Joy UIをalpha → betaにしたタイミング(#66)でレイアウトの微小な変化が起きており、それ以降長らく要素が画面幅をはみ出している状態でした。スタイルを整理した結果これを修正することができ、以前のレイアウトに近いものになりました。