### PR TITLE
fix: 画面高が大きい場合にソースコードタブが画面下に揃わない問題を修正

### DIFF
--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -28,6 +28,7 @@ const Layout = () => (
         flexDirection: "column",
         alignItems: "center",
         gap: "2.5rem",
+        flexGrow: 1,
       }}
     >
       <Outlet />


### PR DESCRIPTION
close #524 

昔の挙動と同じになったはずです
(これ別に`Good first issue`じゃなくない？？？)