### PR TITLE
feat: idがないときにソースコードタブを押せないようにした

### DIFF
--- a/src/components/SourceCodeTab.tsx
+++ b/src/components/SourceCodeTab.tsx
@@ -31,7 +31,7 @@ export const SourceCodeTab = ({ sourceCode }: CodeProps) => {
     setHtml(html);
   }, [sourceCode, highlighter]);
   const [showCopied, setShowCopied] = useState(false);
-
+  const isCode = sourceCode ? true : false;
   return (
     <Box
       sx={{
@@ -52,8 +52,9 @@ export const SourceCodeTab = ({ sourceCode }: CodeProps) => {
           sx={{
             height: "2rem",
           }}
+          disabled={!isCode}
         >
-          <Typography color="primary">
+          <Typography color={isCode ? "primary" : "neutral"}>
             {isOpen ? t("ソースコードを非表示") : t("ソースコードを表示")}
           </Typography>
         </Button>

--- a/src/components/SourceCodeTab.tsx
+++ b/src/components/SourceCodeTab.tsx
@@ -70,7 +70,6 @@ export const SourceCodeTab = ({ sourceCode }: CodeProps) => {
           >
             <IconButton
               onClick={() => handleCopy()}
-              disabled={!sourceCode}
               color="primary"
               sx={{
                 position: "absolute",


### PR DESCRIPTION

ボタンを押せないようにしました.文字の色を灰色にしました
コピーボタンにソースコードがないときに押せないようにしていましたが、いらなくなったので消しました
