### PR TITLE
fix: 接続直後にフリーズすることがある問題を修正

### DIFF
--- a/src/libs/mrubyWriterConnector.ts
+++ b/src/libs/mrubyWriterConnector.ts
@@ -102,16 +102,7 @@ export class MrubyWriterConnector {
     try {
       this.handleText("\r\n\u001b[32m> try to disconnect...\u001b[0m\r\n");
 
-      this.aborter?.abort(new Error("disconnect is called."));
-      await this.mainReadableStreamClosed?.catch(() => undefined);
-
-      await this.currentSubReader?.cancel(() => undefined);
-      this.currentSubReader?.releaseLock();
-
-      await this.mainReadable?.cancel().catch(() => undefined);
-      await this.subReadable?.cancel().catch(() => undefined);
-      await this.port.writable?.abort().catch(() => undefined);
-
+      await this.abortStreams();
       const res = await this.close();
       if (res.isFailure()) {
         this.handleText(
@@ -527,5 +518,17 @@ export class MrubyWriterConnector {
       this.handleText("\r\n\u001b[31m failed to verify. \r\n");
       return Failure.error("Failed to verify.");
     }
+  }
+
+  private async abortStreams(): Promise<void> {
+    this.aborter?.abort(new Error("disconnect is called."));
+    await this.mainReadableStreamClosed?.catch(console.warn);
+
+    await this.currentSubReader?.cancel().catch(console.warn);
+    this.currentSubReader?.releaseLock();
+
+    await this.mainReadable?.cancel().catch(console.warn);
+    await this.subReadable?.cancel().catch(console.warn);
+    await this.port?.writable?.abort().catch(console.warn);
   }
 }

--- a/src/libs/mrubyWriterConnector.ts
+++ b/src/libs/mrubyWriterConnector.ts
@@ -365,22 +365,6 @@ export class MrubyWriterConnector {
     }
   }
 
-  private getSubReader(): Result<Reader, Error> {
-    if (!this.port) {
-      return Failure.error("No port.");
-    }
-    if (!this.subReadable) {
-      return Failure.error("Cannot read serial port.");
-    }
-
-    try {
-      this.currentSubReader?.releaseLock();
-      return Success.value(this.subReadable.getReader());
-    } catch (error) {
-      return Failure.error("Failed to get reader.", { cause: error });
-    }
-  }
-
   private getWriter(): Result<Writer, Error> {
     if (!this.port) {
       return Failure.error("No port.");
@@ -434,9 +418,6 @@ export class MrubyWriterConnector {
     if (this._writeMode) {
       return Failure.error("Already write mode.");
     }
-    if (!this.subReadable) {
-      return Failure.error("Cannot read serial port.");
-    }
     if (!this.port.writable) {
       return Failure.error("Cannot write serial port.");
     }
@@ -447,19 +428,6 @@ export class MrubyWriterConnector {
   private async onExitWriteMode(): Promise<Success<null>> {
     this._writeMode = false;
     return Success.value(null);
-  }
-
-  private async read(reader: Reader): Promise<Result<string, Error>> {
-    try {
-      const { done, value } = await reader.read();
-      if (done) {
-        return Failure.error("Reader is canceled.");
-      }
-
-      return Success.value(this.decoder.decode(value));
-    } catch (error) {
-      return Failure.error("Error excepted while reading.", { cause: error });
-    }
   }
 
   private async write(

--- a/src/libs/mrubyWriterConnector.ts
+++ b/src/libs/mrubyWriterConnector.ts
@@ -403,7 +403,7 @@ export class MrubyWriterConnector {
 
           enqueue(value);
         } catch (error) {
-          console.error(error);
+          console.warn(error);
           break;
         }
       }

--- a/src/libs/mrubyWriterConnector.ts
+++ b/src/libs/mrubyWriterConnector.ts
@@ -215,7 +215,7 @@ export class MrubyWriterConnector {
 
     await this.completeJobs();
     this.handleText(`\r\n> ${command}\r\n`);
-    console.log("Send", { command });
+    this.log("Send", { command });
 
     return this.sendData(this.encoder.encode(`${command}\r\n`), {
       ignoreResponse: option?.ignoreResponse,
@@ -257,7 +257,7 @@ export class MrubyWriterConnector {
     const clearRes = await this.sendCommand("clear");
     if (clearRes.isFailure()) return clearRes;
 
-    console.log(clearRes);
+    this.log("Clear", clearRes);
     const writeSizeRes = await this.sendCommand(`write ${binary.byteLength}`);
     if (writeSizeRes.isFailure()) return writeSizeRes;
 

--- a/src/libs/mrubyWriterConnector.ts
+++ b/src/libs/mrubyWriterConnector.ts
@@ -534,14 +534,18 @@ export class MrubyWriterConnector {
   }
 
   private async abortStreams(): Promise<void> {
-    this.aborter?.abort(new Error("disconnect is called."));
-    await this.mainReadableStreamClosed?.catch(console.warn);
+    this.sinkAborter?.abort("abortStreams");
+    await this.sinkClosed?.catch(console.warn);
 
-    await this.currentSubReader?.cancel().catch(console.warn);
-    this.currentSubReader?.releaseLock();
+    this.sourceAborter?.abort("abortStreams");
+    await this.sourceClosed?.catch(console.warn);
 
-    await this.mainReadable?.cancel().catch(console.warn);
-    await this.subReadable?.cancel().catch(console.warn);
+    await this.sourceReader?.cancel().catch(console.warn);
+    this.sourceReader?.releaseLock();
+
+    await this.readable?.cancel().catch(console.warn);
+
+    await this.port?.readable?.cancel().catch(console.warn);
     await this.port?.writable?.abort().catch(console.warn);
   }
 


### PR DESCRIPTION
cf. #494 

## なぜフリーズしていたか

このパターンのフリーズをトリガーするのは、マイコンもしくはケーブルに不具合があって不正なデータが送られてきたときに発生するエラーであることがわかりました。不正なデータを受け取った場合、`reader.read()`が`FramingError`を throw します。その後キャッシュされている`port.readable`から`reader`を取得しなおしますが、実際には`port.readable`自体が新しいものに更新されており、既存の実装では古くなった`readable`から再度`reader`を取得しようとしたことでハングしていました。

## 変更

先述の通り、`FramingError`などの Fatal でないエラーが発生したときは`port.readable`が更新されます。なので、初期化処理自体をループにして、`reader.read()`がエラーになった際に`port.readable`が`null`になっていない限り初期化処理からやり直すようにすれば解決します。
しかしながら、`writeCode`などから`sendCommand`が呼ばれる際、コマンドの結果を得るために`startListen`が持っている読み権限を奪う必要があり、`currentSubReader.releaseLock()`を呼び出して待機中の`reader.read()`をキャンセルして行っています。この場合にも`reader.read()`はエラーになるので、先述の初期化のやり直しに入ってしまい読み権限の取得が競合してエラーになります。
ここが**ログの出力と、コマンド結果に要らない出力を読み捨てつつ読み権限を管理するのに`mainReader`-`subReader`機構を使う限界**だと考えました。そこで以下のように**どちらの読み込みにもパイプを使う**機構に変更しました。

```mermaid
graph LR
  O["Origin source<br/>(ReadableStream)"] -. blocking-read .->
  A["Source stream<br/>(ReadableStream)"] --> B["Decoder<br/>(TransformStream)"]
  B --> C["Logging<br/>(TransformStream)"]
  C --> D["Empty sink<br/>(WritableStream)"]
  C --> E["Command output reader<br/>(WritableStream)"]
```

読み捨てるときは`Empty sink`に結果を流し、コマンド結果を読みたいときは`Empty sink`を外して、代わりに専用の`WritableStream`を接続することで、`subReader`の奪取と同じ仕組みを blocking-read 無しで実現しています。
一方、`port.readable`からそのままパイプをつなげてしまうと、そもそもの`FramingError`発生時にStream全体が破棄されてしまい、 Fatal でないエラーからの回復処理を挟む余地がありません。そこで、`port.readable` ( 図中では `Origin source` ) からの blocking-read 自体は残しつつ、これを更に `ReadableStream` としてラップすることで、 Fatal でないエラーからの回復処理を内部で行ってくれるStream ( 図中では `Source stream` ) を作り、ここをパイプの始点としています。

## 見てほしいこと

- マイコンが実行モードになった後に接続して書き込みモードに入るパターンでフリーズしないこと
  - 正しくハンドリングが行えている場合、コンソールに`FramingError: Framing error`という warning が出ます。
  - Lチカなど実行モードに入ったことが見て分かるプログラムを書きこんでおくと試しやすいです。
- 接続・書き込み・検証・切断など実行できる操作が一通り正しく行えること
  - 内部の構造が大きく変わっているので、いつもより厳しめにテストしてほしいです。