### PR TITLE
chore: ステージングデプロイのスクリプトにmise用の記述を追加

### DIFF
--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -32,6 +32,10 @@ jobs:
             cd kaniwriter
             git checkout main
             git pull
+
+            mise install
+            mise prune --yes
+
             pnpm install --frozen-lockfile
             pnpm build:ceres
 


### PR DESCRIPTION
`.node-version`が更新されたときに`mise install`の再実行が必要なため