### PR TITLE
chore: ビルドスクリプトの環境変数 `CI` を `true` に設定

### DIFF
--- a/.github/workflows/cd-production.yaml
+++ b/.github/workflows/cd-production.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: deploy
         uses: appleboy/ssh-action@v1
         env:
+          CI: true
           DEPLOY_TARGET_DIR: ${{ secrets.DEPLOY_TARGET_DIR }}
           DEPLOY_BUILD_OUTPUT_DIR: ${{ secrets.DEPLOY_BUILD_OUTPUT_DIR }}
         with:

--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: deploy
         uses: appleboy/ssh-action@v1
         env:
+          CI: true
           DEPLOY_TARGET_DIR: ${{ secrets.DEPLOY_TARGET_DIR }}
           DEPLOY_BUILD_OUTPUT_DIR: ${{ secrets.DEPLOY_BUILD_OUTPUT_DIR }}
         with:


### PR DESCRIPTION
close #1216 