### PR TITLE
feat(experimental): RP2040 との接続時に Break 信号を送信する機能を実験的に追加

### DIFF
--- a/src/hooks/useMrbwrite.ts
+++ b/src/hooks/useMrbwrite.ts
@@ -22,6 +22,7 @@ export type Method<Middleware extends MrbwriteMiddleware<unknown>> = {
   verify: (
     ...props: Parameters<MrbwriteController<Middleware>["verify"]>
   ) => Promise<Result<void, Error>>;
+  sendBreak: () => Promise<void>;
 };
 
 type UseMrbwrite<Middleware extends MrbwriteMiddleware<unknown>> = {
@@ -174,6 +175,11 @@ export const useMrbwrite = <Target>(
     [connector, notify, notifyError]
   );
 
+  const sendBreak = useCallback(
+    async () => await connector.sendBreak(),
+    [connector.sendBreak]
+  );
+
   const method = useMemo(
     (): Method<Middleware> => ({
       connect,
@@ -184,6 +190,7 @@ export const useMrbwrite = <Target>(
       sendCommand,
       writeCode,
       verify,
+      sendBreak,
     }),
     [
       connect,
@@ -194,6 +201,7 @@ export const useMrbwrite = <Target>(
       sendCommand,
       writeCode,
       verify,
+      sendBreak,
     ]
   );
 

--- a/src/libs/mrbwrite/controller.ts
+++ b/src/libs/mrbwrite/controller.ts
@@ -258,7 +258,10 @@ export class MrbwriteController<
 
   async sendBreak(): Promise<void> {
     this.handleText(`\r\n${green("> send break signal.")}\r\n`);
-    await this.middleware.sendBreak?.();
+    const res = await this.middleware.sendBreak?.();
+    if (res?.isFailure()) {
+      console.warn(res.error);
+    }
   }
 
   private async sendData(

--- a/src/libs/mrbwrite/controller.ts
+++ b/src/libs/mrbwrite/controller.ts
@@ -87,6 +87,12 @@ export class MrbwriteController<
     }
 
     this.handleText(`\r\n${green("> connection established.")}\r\n`);
+
+    // FIXME: 仮実装なので直す
+    if (this.middleware.getProfile()?.name == "RP2040") {
+      await this.sendBreak();
+    }
+
     return Success.value(null);
   }
 
@@ -248,6 +254,11 @@ export class MrbwriteController<
       await this.sendCommand("execute");
     }
     return Success.value(writeRes.value);
+  }
+
+  async sendBreak(): Promise<void> {
+    this.handleText(`\r\n${green("> send break signal.")}\r\n`);
+    await this.middleware.sendBreak?.();
   }
 
   private async sendData(

--- a/src/libs/mrbwrite/middleware.ts
+++ b/src/libs/mrbwrite/middleware.ts
@@ -19,6 +19,9 @@ export interface MrbwriteMiddleware<Device> {
   getWritable(): Result<WritableStream<Uint8Array>, Error>;
 
   cancel(): Promise<Result<void, Error>>;
+
+  // FIXME: 仮実装
+  sendBreak?(): Promise<void>;
 }
 
 export { serialMiddleware } from "./middlewares/serial";

--- a/src/libs/mrbwrite/middleware.ts
+++ b/src/libs/mrbwrite/middleware.ts
@@ -21,7 +21,7 @@ export interface MrbwriteMiddleware<Device> {
   cancel(): Promise<Result<void, Error>>;
 
   // FIXME: 仮実装
-  sendBreak?(): Promise<void>;
+  sendBreak?(): Promise<Result<void, Error>>;
 }
 
 export { serialMiddleware } from "./middlewares/serial";

--- a/src/libs/mrbwrite/middlewares/serial.ts
+++ b/src/libs/mrbwrite/middlewares/serial.ts
@@ -159,17 +159,23 @@ export class MrbwriteSerialMiddleware
   }
 
   // FIXME: 仮実装
-  async sendBreak(): Promise<void> {
+  async sendBreak(): Promise<Result<void, Error>> {
     const port = this.port;
     if (!port) {
-      return;
+      return Failure.error("No port.");
     }
 
-    await port.setSignals({ break: true });
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    if (port.connected) {
-      await port.setSignals({ break: false });
+    try {
+      await port.setSignals({ break: true });
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      if (port.connected) {
+        await port.setSignals({ break: false });
+      }
+    } catch (error) {
+      return Failure.error("Failed to send break signal.", { cause: error });
     }
+
+    return Success.value(undefined);
   }
 }
 

--- a/src/libs/mrbwrite/middlewares/serial.ts
+++ b/src/libs/mrbwrite/middlewares/serial.ts
@@ -167,7 +167,7 @@ export class MrbwriteSerialMiddleware
 
     try {
       await port.setSignals({ break: true });
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       if (port.connected) {
         await port.setSignals({ break: false });
       }

--- a/src/libs/mrbwrite/middlewares/serial.ts
+++ b/src/libs/mrbwrite/middlewares/serial.ts
@@ -157,6 +157,20 @@ export class MrbwriteSerialMiddleware
 
     return Success.value(undefined);
   }
+
+  // FIXME: 仮実装
+  async sendBreak(): Promise<void> {
+    const port = this.port;
+    if (!port) {
+      return;
+    }
+
+    await port.setSignals({ break: true });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    if (port.connected) {
+      await port.setSignals({ break: false });
+    }
+  }
 }
 
 export const serialMiddleware = new MrbwriteSerialMiddleware(navigator.serial);

--- a/src/libs/mrbwrite/profile.ts
+++ b/src/libs/mrbwrite/profile.ts
@@ -1,4 +1,5 @@
 export type MrbwriteProfile = {
+  name: string;
   baudRate: number;
   keyword: {
     enterWriteMode: RegExp;
@@ -12,6 +13,7 @@ const defineProfile = <const P extends MrbwriteProfile>(profile: P): P =>
 // TODO: 将来的にはボードごとに異なるキーワードを使わないようにする;
 
 export const esp32 = defineProfile({
+  name: "ESP32",
   baudRate: 115200,
   keyword: {
     enterWriteMode: /\+OK mruby\/c/,
@@ -20,6 +22,7 @@ export const esp32 = defineProfile({
 });
 
 export const rboard = defineProfile({
+  name: "RBoard",
   baudRate: 19200,
   keyword: {
     enterWriteMode: /\+OK mruby\/c/,
@@ -28,6 +31,7 @@ export const rboard = defineProfile({
 });
 
 export const rp2040 = defineProfile({
+  name: "RP2040",
   baudRate: 19200,
   keyword: {
     enterWriteMode: /\+OK mruby\/c/,

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/joy";
+import { Box, Button } from "@mui/joy";
 import { CommandInput } from "components/CommandInput";
 import { Log } from "components/Log";
 import { SourceCodeTab } from "components/SourceCodeTab";
@@ -130,11 +130,32 @@ export const Home = () => {
         >
           <Log log={log} autoScroll={option.autoScroll} />
           <ControlButtons />
-          <CommandInput
-            onSubmit={(command) =>
-              method.sendCommand(command, { force: true, ignoreResponse: true })
-            }
-          />
+          <Box
+            sx={{
+              display: "flex",
+              gap: "1rem",
+              justifyContent: "right",
+            }}
+          >
+            <CommandInput
+              onSubmit={(command) =>
+                method.sendCommand(command, {
+                  force: true,
+                  ignoreResponse: true,
+                })
+              }
+            />
+            {target == "RP2040" && (
+              <Button
+                onClick={() => method.sendBreak()}
+                variant="outlined"
+                color="neutral"
+                size="sm"
+              >
+                Break
+              </Button>
+            )}
+          </Box>
         </Box>
       </Box>
       <SourceCodeTab sourceCode={sourceCode} disable={!id} />


### PR DESCRIPTION
close #1247

### 概要

RP2040 との接続を開始した際に Break 信号を送信するようにしています。
また、ターゲットに RP2040 を選んだときのみコマンド入力欄の右に `Break` ボタンが表示されるようになっています。

~~**注: Break 信号によるソフトリセットで接続が切れるため、現在は期待通りの動作になっていません。**#1249 が入ると、再度接続可能になったタイミングで自動接続が行われるようになるので期待通りの動作になるはずです。~~

### その他

- 実装内容はすべて仮であり、抽象レベルがおかしくなっています。今後のリファクタリングなどに伴い改善したいです。
- 手元の Pico ではソフトリセットの挙動が確認ができています。
- ~~同様の理由で、現段階では RP2040 との通信時に `reset` コマンドを送るパターンでも接続が切れるようです。~~