### PR TITLE
chore: ランタイムの Sentry 有効化を Production 時のみに限定

### DIFF
--- a/src/utils/sentryInitialize.ts
+++ b/src/utils/sentryInitialize.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/react";
 
-if (import.meta.env.VITE_SENTRY_ENABLED === "true") {
+if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_ENABLED === "true") {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
     ignoreErrors: ["Already write mode.", "No port."],


### PR DESCRIPTION
close #1326

#1297 の対応漏れ