### PR TITLE
feat(develop/replace-ui): `UnsupportedBrowserModal` コンポーネントをMantineに移行

### DIFF
--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -18,14 +18,13 @@ export const UnsupportedBrowserModal = ({
       onClose={() => setOpen(false)}
       withCloseButton={false}
       centered
-      size="50rem"
+      size="fit-content"
       radius="0.5rem"
       padding={0}
       styles={{
         content: {
-          width: "80%",
-          minWidth: "500px",
           border: "1px solid var(--mantine-color-neutral-3)",
+          fontSize: "0.875"
         },
       }}
     >

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -38,7 +38,7 @@ export const UnsupportedBrowserModal = ({
           boxShadow: "none",
           minWidth: "500px",
           fontSize: "0.875rem",
-          outline: `2px solid ${theme.colors.primary[5]}`,
+          outline: `2px solid #0060df`,
           border: `1px solid ${theme.colors.neutral[3]}`,
         },
         body: {

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -29,10 +29,16 @@ export const UnsupportedBrowserModal = ({
         },
       }}
     >
-      <Title order={4} fz="1.25rem" mt="0.5rem" m="0.5rem" style={{fontWeight: "bold"}}>
+      <Title
+        order={4}
+        fz="1.25rem"
+        mt="0.5rem"
+        m="0.5rem"
+        style={{ fontWeight: "bold" }}
+      >
         {t("このブラウザはサポートされていません")}
       </Title>
- 
+
       <CloseButton
         variant="transparent"
         onClick={() => setOpen(false)}

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -21,6 +21,11 @@ export const UnsupportedBrowserModal = ({
       size="fit-content"
       radius="0.5rem"
       padding={0}
+      overlayProps={{
+        backgroundOpacity: 0.25,
+        color: "#0B0D0E",
+        blur: 8,
+      }}
       styles={{
         content: {
           border: "1px solid var(--mantine-color-neutral-3)",

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -33,7 +33,7 @@ export const UnsupportedBrowserModal = ({
         fz="1.25rem"
         mt="0.5rem"
         m="0.5rem"
-        style={{ fontWeight: "bold" }}
+        style={{ fontWeight: "bold", letterSpacing: "-0.055em" }}
       >
         {t("このブラウザはサポートされていません")}
       </Title>

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   CloseButton,
   Modal,
   Text,
@@ -38,14 +39,23 @@ export const UnsupportedBrowserModal = ({
           boxShadow: "none",
           minWidth: "500px",
           fontSize: "0.875rem",
-          outline: `2px solid #0060df`,
           border: `1px solid ${theme.colors.neutral[3]}`,
+          overflow: "visible",
         },
         body: {
           overflow: "visible",
         },
       }}
     >
+      <Box
+        pos="absolute"
+        inset={-2.8}
+        bd="2px solid #0060df"
+        bdrs="0.625rem"
+        style={{
+          outline: "1px solid white",
+        }}
+      />
       <Title
         order={4}
         fz="1.25rem"

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, ModalClose, Sheet, Typography } from "@mui/joy";
+import { CloseButton, Modal, Text, Title } from "@mantine/core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -11,30 +11,40 @@ export const UnsupportedBrowserModal = ({
 }: UnsupportedBrowserModalProps) => {
   const [open, setOpen] = useState(defaultOpen);
   const [t] = useTranslation();
+
   return (
     <Modal
-      open={open}
+      opened={open}
       onClose={() => setOpen(false)}
-      sx={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        width: "90%",
-        minWidth: "500px",
-        m: "auto",
-        maxWidth: "60rem",
+      withCloseButton={false}
+      centered
+      size="50rem"
+      radius="0.5rem"
+      padding={0}
+      styles={{
+        content: {
+          width: "80%",
+          minWidth: "500px",
+          border: "1px solid var(--mantine-color-neutral-3)",
+        },
       }}
     >
-      <Sheet variant="outlined" sx={{ borderRadius: "0.5rem" }}>
-        <Typography level="h4" m={1} alignItems="center">
-          {t("このブラウザはサポートされていません")}
-        </Typography>
-        <ModalClose variant="plain" sx={{ m: 0.5 }} />
+      <Title order={4} mt="0.5rem" m="0.5rem" style={{fontWeight: "bold"}}>
+        {t("このブラウザはサポートされていません")}
+      </Title>
+ 
+      <CloseButton
+        variant="transparent"
+        onClick={() => setOpen(false)}
+        pos="absolute"
+        top="0.75rem"
+        right="0.75rem"
+        m="0.25rem"
+      />
 
-        <Typography fontSize="sm" m="0.5rem" whiteSpace="pre-line">
-          {t("対応するブラウザを使ってください")}
-        </Typography>
-      </Sheet>
+      <Text fz="0.8rem" m="0.5rem" style={{ whiteSpace: "pre-line" }}>
+        {t("対応するブラウザを使ってください")}
+      </Text>
     </Modal>
   );
 };

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -28,16 +28,20 @@ export const UnsupportedBrowserModal = ({
       }}
       styles={{
         content: {
-          border: "1px solid var(--mantine-color-neutral-3)",
-          fontSize: "0.875"
+          fontSize: "0.875",
+          outline: "3px solid var(--mantine-color-primary-4)",
+          outlineOffset: "0.17rem",
         },
+        body: {
+          overflow: "visible",
+        }
       }}
     >
       <Title
         order={4}
         fz="1.25rem"
         mt="0.5rem"
-        m="0.5rem"
+        m="8px"
         style={{ fontWeight: "bold", letterSpacing: "-0.055em" }}
       >
         {t("このブラウザはサポートされていません")}
@@ -52,7 +56,7 @@ export const UnsupportedBrowserModal = ({
         m="0.25rem"
       />
 
-      <Text fz="0.85rem" m="0.5rem" style={{ whiteSpace: "pre-line" }}>
+      <Text fz="0.875rem" m="0.5rem" style={{ whiteSpace: "pre-line" }}>
         {t("対応するブラウザを使ってください")}
       </Text>
     </Modal>

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -42,7 +42,7 @@ export const UnsupportedBrowserModal = ({
         fz="1.25rem"
         mt="0.5rem"
         m="8px"
-        style={{ fontWeight: "bold", letterSpacing: "-0.055em" }}
+        style={{ fontWeight: "bold", letterSpacing: "-0.025em" }}
       >
         {t("このブラウザはサポートされていません")}
       </Title>

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -29,7 +29,7 @@ export const UnsupportedBrowserModal = ({
         },
       }}
     >
-      <Title order={4} mt="0.5rem" m="0.5rem" style={{fontWeight: "bold"}}>
+      <Title order={4} fz="1.25rem" mt="0.5rem" m="0.5rem" style={{fontWeight: "bold"}}>
         {t("このブラウザはサポートされていません")}
       </Title>
  
@@ -42,7 +42,7 @@ export const UnsupportedBrowserModal = ({
         m="0.25rem"
       />
 
-      <Text fz="0.8rem" m="0.5rem" style={{ whiteSpace: "pre-line" }}>
+      <Text fz="0.85rem" m="0.5rem" style={{ whiteSpace: "pre-line" }}>
         {t("対応するブラウザを使ってください")}
       </Text>
     </Modal>

--- a/src/components/UnsupportedBrowserModal.tsx
+++ b/src/components/UnsupportedBrowserModal.tsx
@@ -1,4 +1,10 @@
-import { CloseButton, Modal, Text, Title } from "@mantine/core";
+import {
+  CloseButton,
+  Modal,
+  Text,
+  Title,
+  useMantineTheme,
+} from "@mantine/core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -11,6 +17,7 @@ export const UnsupportedBrowserModal = ({
 }: UnsupportedBrowserModalProps) => {
   const [open, setOpen] = useState(defaultOpen);
   const [t] = useTranslation();
+  const theme = useMantineTheme();
 
   return (
     <Modal
@@ -23,26 +30,28 @@ export const UnsupportedBrowserModal = ({
       padding={0}
       overlayProps={{
         backgroundOpacity: 0.25,
-        color: "#0B0D0E",
+        color: "#32383e",
         blur: 8,
       }}
       styles={{
         content: {
-          fontSize: "0.875",
-          outline: "3px solid var(--mantine-color-primary-4)",
-          outlineOffset: "0.17rem",
+          boxShadow: "none",
+          minWidth: "500px",
+          fontSize: "0.875rem",
+          outline: `2px solid ${theme.colors.primary[5]}`,
+          border: `1px solid ${theme.colors.neutral[3]}`,
         },
         body: {
           overflow: "visible",
-        }
+        },
       }}
     >
       <Title
         order={4}
         fz="1.25rem"
-        mt="0.5rem"
-        m="8px"
-        style={{ fontWeight: "bold", letterSpacing: "-0.025em" }}
+        lh="1.875rem"
+        m="0.5rem"
+        style={{ fontWeight: 600, letterSpacing: "-0.025em" }}
       >
         {t("このブラウザはサポートされていません")}
       </Title>
@@ -54,6 +63,9 @@ export const UnsupportedBrowserModal = ({
         top="0.75rem"
         right="0.75rem"
         m="0.25rem"
+        style={{
+          outline: "none",
+        }}
       />
 
       <Text fz="0.875rem" m="0.5rem" style={{ whiteSpace: "pre-line" }}>


### PR DESCRIPTION
close #985 